### PR TITLE
Traverse the family tree to determine blood relation

### DIFF
--- a/src/person.rb
+++ b/src/person.rb
@@ -8,7 +8,16 @@ class Person
   end
 
   def is_related_to?(person)
-
+    !person.nil? && person != self && (
+      person == @father ||
+      person == @mother ||
+      self == person.father ||
+      self == person.mother ||
+      is_related_to?(person.father) ||
+      is_related_to?(person.mother) ||
+      (!@father.nil? && @father.is_related_to?(person)) ||
+      (!@mother.nil? && @mother.is_related_to?(person))
+    )
   end
 
 end


### PR DESCRIPTION
I decided to opt for bob.is_related_to?(bob) to be false since it wasn't defined otherwise. If we consider bob to be related to himself this could be paired down further to something like

```
    person == self || !person.nil? && (
      is_related_to?(person.father) ||
      is_related_to?(person.mother) ||
      (!@father.nil? && @father.is_related_to?(person)) ||
      (!@mother.nil? && @mother.is_related_to?(person))
    )
```